### PR TITLE
feat: add readiness and liveness health probes

### DIFF
--- a/calculate-service/app/__init__.py
+++ b/calculate-service/app/__init__.py
@@ -30,6 +30,12 @@ def create_app() -> FastAPI:
 
     app.add_middleware(RequestContextMiddleware)
 
+    # Store frequently used resources on the application state so ancillary
+    # components (health checks, background tasks, etc.) can reuse them without
+    # rebuilding instances.
+    app.state.settings = settings
+    app.state.templates = templates
+
     app.include_router(health.router)
     app.include_router(pages.get_router(templates))
     app.include_router(problems.router)

--- a/calculate-service/app/routers/health.py
+++ b/calculate-service/app/routers/health.py
@@ -1,11 +1,26 @@
-from fastapi import APIRouter
+from typing import Any, Dict
+
+from fastapi import APIRouter, Request
+
+from ..status import collect_liveness_status, collect_readiness_status
+
 
 router = APIRouter(tags=["health"])
 
 
 @router.get("/health", summary="Service health check")
-async def health_check() -> dict[str, str]:
-    return {"status": "healthy", "message": "Calculate Service is running"}
+async def health_check(request: Request) -> Dict[str, Any]:
+    return collect_liveness_status(request.app)
+
+
+@router.get("/healthz", summary="Liveness probe")
+async def healthz(request: Request) -> Dict[str, Any]:
+    return collect_liveness_status(request.app)
+
+
+@router.get("/readyz", summary="Readiness probe")
+async def readyz(request: Request) -> Dict[str, Any]:
+    return collect_readiness_status(request.app)
 
 
 __all__ = ["router"]

--- a/calculate-service/app/status.py
+++ b/calculate-service/app/status.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from jinja2 import TemplateNotFound, __version__ as jinja_version
+
+from .config import get_settings
+from .problem_bank import list_categories
+
+
+def _get_app_version(app: FastAPI) -> str:
+    settings = getattr(app.state, "settings", None)
+    if settings is not None:
+        return getattr(settings, "app_version", app.version or "unknown")
+    if app.version:
+        return app.version
+    return get_settings().app_version
+
+
+def _dependency_status() -> Dict[str, Dict[str, Any]]:
+    return {
+        "jinja2": {
+            "status": "ok",
+            "version": jinja_version,
+        }
+    }
+
+
+def _templates_status(app: FastAPI) -> Dict[str, Any]:
+    templates = getattr(app.state, "templates", None)
+    if templates is None:
+        return {"status": "error", "detail": "Templates are not configured"}
+
+    try:
+        template = templates.get_template("index.html")
+    except TemplateNotFound as exc:  # pragma: no cover - defensive guard
+        return {"status": "error", "detail": str(exc)}
+
+    return {
+        "status": "ok",
+        "template": template.name,
+    }
+
+
+def _problem_bank_status() -> Dict[str, Any]:
+    try:
+        categories = list_categories()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return {"status": "error", "detail": str(exc)}
+
+    return {
+        "status": "ok" if categories else "error",
+        "category_count": len(categories),
+    }
+
+
+def collect_liveness_status(app: FastAPI) -> Dict[str, Any]:
+    version = _get_app_version(app)
+    details = {
+        "application": {"status": "running"},
+        "dependencies": _dependency_status(),
+    }
+    return {"status": "healthy", "version": version, "details": details}
+
+
+def collect_readiness_status(app: FastAPI) -> Dict[str, Any]:
+    payload = collect_liveness_status(app)
+
+    readiness_checks = {
+        "templates": _templates_status(app),
+        "problem_bank": _problem_bank_status(),
+    }
+    is_ready = all(check["status"] == "ok" for check in readiness_checks.values())
+
+    payload["status"] = "ready" if is_ready else "degraded"
+    payload["details"]["readiness"] = readiness_checks
+    return payload
+
+
+__all__ = [
+    "collect_liveness_status",
+    "collect_readiness_status",
+]

--- a/calculate-service/tests/test_api.py
+++ b/calculate-service/tests/test_api.py
@@ -55,6 +55,28 @@ def test_health_endpoint_returns_status(client) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "healthy"
+    assert "version" in payload
+    assert "details" in payload
+    assert "dependencies" in payload["details"]
+
+
+def test_healthz_endpoint_reports_dependencies(client) -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    dependencies = payload["details"]["dependencies"]
+    assert dependencies["jinja2"]["status"] == "ok"
+
+
+def test_readyz_endpoint_reports_readiness(client) -> None:
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ready"
+    readiness = payload["details"]["readiness"]
+    assert readiness["templates"]["status"] == "ok"
+    assert readiness["problem_bank"]["status"] == "ok"
 
 
 def test_default_problem_category_is_returned(client) -> None:

--- a/docs/calculate_service_overview.md
+++ b/docs/calculate_service_overview.md
@@ -1,0 +1,13 @@
+# Calculate Service Overview
+
+## Endpoints
+
+| Method | Path         | Description |
+|--------|--------------|-------------|
+| GET    | `/health`    | Returns overall service health information including the deployed version and dependency summaries. |
+| GET    | `/healthz`   | Lightweight liveness probe that mirrors `/health` and is suitable for container orchestrator health checks. |
+| GET    | `/readyz`    | Readiness probe that validates template loading and problem data availability before routing production traffic. |
+| GET    | `/api/problems` | Fetches a list of practice problems for an optional category. |
+| GET    | `/problems`  | Renders the HTML landing page for browsing practice problems. |
+
+Each health response includes a `status` field for quick inspection and a `details` object that surfaces dependency and readiness diagnostics for observability tooling.


### PR DESCRIPTION
## Summary
- collect calculate-service health diagnostics including version and dependency data
- expose /healthz and /readyz endpoints that reuse the shared status collector
- document the new health checks and cover them with API tests

## Testing
- pytest calculate-service/tests/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ddecdea378832bba512500493d7da5