### PR TITLE
feat: persist problem data and submission attempts

### DIFF
--- a/calculate-service/.gitignore
+++ b/calculate-service/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+app/data/*.db

--- a/calculate-service/app/__init__.py
+++ b/calculate-service/app/__init__.py
@@ -1,11 +1,13 @@
+from contextlib import asynccontextmanager
 from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .config import get_settings
 from .instrumentation import RequestContextMiddleware
-from .problem_bank import refresh_cache
+from .problem_bank import refresh_cache, reset_cache
 from .repositories import AttemptRepository
 from .routers import health, pages, problems
 
@@ -14,12 +16,36 @@ def create_app() -> FastAPI:
     """Create and configure the FastAPI application instance."""
     settings = get_settings()
 
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        problem_repository = refresh_cache(force=True)
+        app.state.problem_repository = problem_repository
+        app.state.problem_cache_strategy = {
+            "strategy": "file-mtime",
+            "source": str(problem_repository.source_path),
+        }
+
+        attempt_repository = AttemptRepository(settings.attempts_database_path)
+        app.state.attempt_repository = attempt_repository
+
+        try:
+            yield
+        finally:
+            if hasattr(app.state, "attempt_repository"):
+                delattr(app.state, "attempt_repository")
+            if hasattr(app.state, "problem_cache_strategy"):
+                delattr(app.state, "problem_cache_strategy")
+            if hasattr(app.state, "problem_repository"):
+                delattr(app.state, "problem_repository")
+            reset_cache()
+
     app = FastAPI(
         title=settings.app_name,
         description=settings.app_description,
         version=settings.app_version,
         docs_url="/docs" if settings.enable_openapi else None,
         redoc_url=None,
+        lifespan=lifespan,
     )
 
     # Ensure templates/tests can resolve relative paths when run from any CWD.
@@ -29,16 +55,6 @@ def create_app() -> FastAPI:
 
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
     templates = Jinja2Templates(directory=template_dir)
-
-    problem_repository = refresh_cache(force=True)
-    app.state.problem_repository = problem_repository
-    app.state.problem_cache_strategy = {
-        "strategy": "file-mtime",
-        "source": str(problem_repository.source_path),
-    }
-
-    attempt_repository = AttemptRepository(settings.attempts_database_path)
-    app.state.attempt_repository = attempt_repository
 
     app.add_middleware(RequestContextMiddleware)
 

--- a/calculate-service/app/config.py
+++ b/calculate-service/app/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 from typing import List
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -10,6 +11,8 @@ class Settings(BaseSettings):
     app_version: str = "1.0.0"
     enable_openapi: bool = True
     allowed_problem_categories: List[str] | None = None
+    problem_data_path: Path = Path(__file__).resolve().parent / "data" / "problems.json"
+    attempts_database_path: Path = Path(__file__).resolve().parent / "data" / "attempts.db"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/calculate-service/app/data/problems.json
+++ b/calculate-service/app/data/problems.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "add-1",
+    "category": "덧셈",
+    "question": "15 + 23 = ?",
+    "answer": 38,
+    "hint": "같은 자리끼리 더한 뒤 받아올림을 확인하세요."
+  },
+  {
+    "id": "add-2",
+    "category": "덧셈",
+    "question": "47 + 18 = ?",
+    "answer": 65,
+    "hint": "일의 자리부터 차근차근 더해보세요."
+  },
+  {
+    "id": "add-3",
+    "category": "덧셈",
+    "question": "32 + 45 = ?",
+    "answer": 77
+  },
+  {
+    "id": "add-4",
+    "category": "덧셈",
+    "question": "56 + 29 = ?",
+    "answer": 85
+  },
+  {
+    "id": "add-5",
+    "category": "덧셈",
+    "question": "78 + 34 = ?",
+    "answer": 112
+  },
+  {
+    "id": "sub-1",
+    "category": "뺄셈",
+    "question": "45 - 12 = ?",
+    "answer": 33
+  },
+  {
+    "id": "sub-2",
+    "category": "뺄셈",
+    "question": "67 - 23 = ?",
+    "answer": 44
+  },
+  {
+    "id": "sub-3",
+    "category": "뺄셈",
+    "question": "89 - 34 = ?",
+    "answer": 55
+  },
+  {
+    "id": "sub-4",
+    "category": "뺄셈",
+    "question": "123 - 45 = ?",
+    "answer": 78
+  },
+  {
+    "id": "sub-5",
+    "category": "뺄셈",
+    "question": "156 - 67 = ?",
+    "answer": 89
+  },
+  {
+    "id": "mul-1",
+    "category": "곱셈",
+    "question": "7 × 8 = ?",
+    "answer": 56
+  },
+  {
+    "id": "mul-2",
+    "category": "곱셈",
+    "question": "6 × 9 = ?",
+    "answer": 54
+  },
+  {
+    "id": "mul-3",
+    "category": "곱셈",
+    "question": "4 × 12 = ?",
+    "answer": 48
+  },
+  {
+    "id": "mul-4",
+    "category": "곱셈",
+    "question": "9 × 7 = ?",
+    "answer": 63
+  },
+  {
+    "id": "mul-5",
+    "category": "곱셈",
+    "question": "8 × 6 = ?",
+    "answer": 48
+  },
+  {
+    "id": "div-1",
+    "category": "나눗셈",
+    "question": "56 ÷ 7 = ?",
+    "answer": 8
+  },
+  {
+    "id": "div-2",
+    "category": "나눗셈",
+    "question": "72 ÷ 8 = ?",
+    "answer": 9
+  },
+  {
+    "id": "div-3",
+    "category": "나눗셈",
+    "question": "45 ÷ 5 = ?",
+    "answer": 9
+  },
+  {
+    "id": "div-4",
+    "category": "나눗셈",
+    "question": "63 ÷ 9 = ?",
+    "answer": 7
+  },
+  {
+    "id": "div-5",
+    "category": "나눗셈",
+    "question": "48 ÷ 6 = ?",
+    "answer": 8
+  }
+]

--- a/calculate-service/app/problem_bank.py
+++ b/calculate-service/app/problem_bank.py
@@ -1,59 +1,236 @@
+from __future__ import annotations
+
+import json
 from dataclasses import dataclass
-from typing import Dict, List
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, Iterable, List
+
+from .config import get_settings
+
+
+class ProblemDataError(RuntimeError):
+    """Base exception for problem data related errors."""
+
+
+class ProblemDataNotFound(ProblemDataError):
+    """Raised when the problem data source cannot be located."""
+
+
+class ProblemDataFormatError(ProblemDataError):
+    """Raised when the problem data source cannot be parsed."""
 
 
 @dataclass(frozen=True, slots=True)
 class Problem:
+    id: str
+    category: str
     question: str
     answer: int
     hint: str | None = None
 
+    def to_dict(self, *, include_answer: bool = False) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "id": self.id,
+            "category": self.category,
+            "question": self.question,
+        }
+        if self.hint is not None:
+            data["hint"] = self.hint
+        if include_answer:
+            data["answer"] = self.answer
+        return data
 
-_PROBLEM_DATA: Dict[str, List[Problem]] = {
-    "덧셈": [
-        Problem(question="15 + 23 = ?", answer=38),
-        Problem(question="47 + 18 = ?", answer=65),
-        Problem(question="32 + 45 = ?", answer=77),
-        Problem(question="56 + 29 = ?", answer=85),
-        Problem(question="78 + 34 = ?", answer=112),
-    ],
-    "뺄셈": [
-        Problem(question="45 - 12 = ?", answer=33),
-        Problem(question="67 - 23 = ?", answer=44),
-        Problem(question="89 - 34 = ?", answer=55),
-        Problem(question="123 - 45 = ?", answer=78),
-        Problem(question="156 - 67 = ?", answer=89),
-    ],
-    "곱셈": [
-        Problem(question="7 × 8 = ?", answer=56),
-        Problem(question="6 × 9 = ?", answer=54),
-        Problem(question="4 × 12 = ?", answer=48),
-        Problem(question="9 × 7 = ?", answer=63),
-        Problem(question="8 × 6 = ?", answer=48),
-    ],
-    "나눗셈": [
-        Problem(question="56 ÷ 7 = ?", answer=8),
-        Problem(question="72 ÷ 8 = ?", answer=9),
-        Problem(question="45 ÷ 5 = ?", answer=9),
-        Problem(question="63 ÷ 9 = ?", answer=7),
-        Problem(question="48 ÷ 6 = ?", answer=8),
-    ],
-}
+
+class ProblemRepository:
+    """Repository that loads problem data from an external JSON/CSV source."""
+
+    def __init__(self, source_path: Path):
+        self.source_path = Path(source_path)
+        self._lock = RLock()
+        self._cache: Dict[str, List[Problem]] = {}
+        self._problem_by_id: Dict[str, Problem] = {}
+        self._last_loaded_at: float | None = None
+
+    def refresh(self, *, force: bool = False) -> None:
+        with self._lock:
+            try:
+                mtime = self.source_path.stat().st_mtime
+            except FileNotFoundError as exc:
+                raise ProblemDataNotFound(
+                    f"Problem data source not found: {self.source_path}"
+                ) from exc
+
+            if not force and self._last_loaded_at is not None:
+                if mtime <= self._last_loaded_at:
+                    return
+
+            raw_text = self.source_path.read_text(encoding="utf-8")
+            try:
+                parsed = json.loads(raw_text)
+            except json.JSONDecodeError as exc:
+                raise ProblemDataFormatError(
+                    f"Invalid problem data format in {self.source_path}"
+                ) from exc
+
+            problems = list(self._coerce_records(parsed))
+            if not problems:
+                raise ProblemDataFormatError(
+                    f"No problem entries discovered in {self.source_path}"
+                )
+
+            cache: Dict[str, List[Problem]] = {}
+            problem_by_id: Dict[str, Problem] = {}
+            for problem in problems:
+                cache.setdefault(problem.category, []).append(problem)
+                problem_by_id[problem.id] = problem
+
+            self._cache = cache
+            self._problem_by_id = problem_by_id
+            self._last_loaded_at = mtime
+
+    def _ensure_loaded(self) -> None:
+        if not self._cache:
+            self.refresh()
+
+    def list_categories(self) -> List[str]:
+        self._ensure_loaded()
+        return list(self._cache.keys())
+
+    def get_problems(self, category: str) -> List[Problem]:
+        self._ensure_loaded()
+        if category in self._cache:
+            return self._cache[category]
+        if not self._cache:
+            raise ProblemDataError("Problem data cache is empty")
+        first_category = next(iter(self._cache))
+        return self._cache[first_category]
+
+    def get_problem(self, problem_id: str) -> Problem:
+        self._ensure_loaded()
+        try:
+            return self._problem_by_id[problem_id]
+        except KeyError as exc:
+            raise ProblemDataError(f"Problem '{problem_id}' does not exist") from exc
+
+    def __len__(self) -> int:
+        self._ensure_loaded()
+        return sum(len(items) for items in self._cache.values())
+
+    def _coerce_records(self, parsed: Any) -> Iterable[Problem]:
+        if isinstance(parsed, dict):
+            for category, entries in parsed.items():
+                if not isinstance(entries, list):
+                    raise ProblemDataFormatError(
+                        "Expected list of problem entries per category"
+                    )
+                for index, raw in enumerate(entries, start=1):
+                    yield self._build_problem(raw, category=category, index=index)
+        elif isinstance(parsed, list):
+            for index, raw in enumerate(parsed, start=1):
+                category = raw.get("category") if isinstance(raw, dict) else None
+                yield self._build_problem(raw, category=category, index=index)
+        else:
+            raise ProblemDataFormatError("Unsupported problem data structure")
+
+    def _build_problem(
+        self, raw: Any, *, category: str | None, index: int
+    ) -> Problem:
+        if not isinstance(raw, dict):
+            raise ProblemDataFormatError("Problem entry must be an object")
+
+        resolved_category = category or raw.get("category")
+        if not resolved_category:
+            raise ProblemDataFormatError("Problem entry is missing category")
+
+        question = raw.get("question")
+        answer = raw.get("answer")
+        if question is None or answer is None:
+            raise ProblemDataFormatError(
+                "Problem entry must include question and answer"
+            )
+
+        try:
+            answer_value = int(answer)
+        except (TypeError, ValueError) as exc:
+            raise ProblemDataFormatError(
+                f"Problem '{question}' has invalid answer value"
+            ) from exc
+
+        hint = raw.get("hint")
+        problem_id = raw.get("id") or f"{resolved_category}-{index}"
+
+        return Problem(
+            id=str(problem_id),
+            category=str(resolved_category),
+            question=str(question),
+            answer=answer_value,
+            hint=str(hint) if hint is not None else None,
+        )
+
+
+_repository_lock = RLock()
+_repository: ProblemRepository | None = None
+
+
+def get_repository() -> ProblemRepository:
+    global _repository
+    with _repository_lock:
+        if _repository is None:
+            settings = get_settings()
+            repository = ProblemRepository(Path(settings.problem_data_path))
+            _repository = repository
+        return _repository
+
+
+def refresh_cache(*, force: bool = False) -> ProblemRepository:
+    repository = get_repository()
+    repository.refresh(force=force)
+    return repository
 
 
 def list_categories() -> List[str]:
-    return list(_PROBLEM_DATA.keys())
+    repository = refresh_cache()
+    return repository.list_categories()
+
+
+def get_problems(category: str) -> List[Problem]:
+    repository = refresh_cache()
+    return repository.get_problems(category)
+
+
+def get_problem(problem_id: str) -> Problem:
+    repository = refresh_cache()
+    return repository.get_problem(problem_id)
 
 
 def get_random_problem(category: str) -> Problem:
     import random
 
     problems = get_problems(category)
+    if not problems:
+        raise ProblemDataError(f"No problems available for category '{category}'")
     return random.choice(problems)
 
 
-def get_problems(category: str) -> List[Problem]:
-    return _PROBLEM_DATA.get(category, _PROBLEM_DATA[list_categories()[0]])
+def reset_cache() -> None:
+    global _repository
+    with _repository_lock:
+        _repository = None
 
 
-__all__ = ["Problem", "list_categories", "get_problems", "get_random_problem"]
+__all__ = [
+    "Problem",
+    "ProblemRepository",
+    "ProblemDataError",
+    "ProblemDataNotFound",
+    "ProblemDataFormatError",
+    "get_repository",
+    "refresh_cache",
+    "list_categories",
+    "get_problems",
+    "get_problem",
+    "get_random_problem",
+    "reset_cache",
+]
+

--- a/calculate-service/app/repositories.py
+++ b/calculate-service/app/repositories.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import RLock
+from typing import Iterable, List
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptRecord:
+    id: int
+    problem_id: str
+    submitted_answer: int
+    is_correct: bool
+    attempted_at: datetime
+
+
+class AttemptRepository:
+    """SQLite-backed repository for storing problem attempts."""
+
+    def __init__(self, database_path: Path):
+        self.database_path = Path(database_path)
+        self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = RLock()
+        self._initialize()
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS attempts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    problem_id TEXT NOT NULL,
+                    submitted_answer INTEGER NOT NULL,
+                    is_correct INTEGER NOT NULL,
+                    attempted_at TEXT NOT NULL
+                )
+                """
+            )
+            connection.commit()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(
+            self.database_path,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            check_same_thread=False,
+        )
+
+    def record_attempt(
+        self, *, problem_id: str, submitted_answer: int, is_correct: bool
+    ) -> AttemptRecord:
+        attempted_at = datetime.now(timezone.utc)
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO attempts (problem_id, submitted_answer, is_correct, attempted_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    problem_id,
+                    int(submitted_answer),
+                    1 if is_correct else 0,
+                    attempted_at.isoformat(),
+                ),
+            )
+            connection.commit()
+            attempt_id = int(cursor.lastrowid)
+        return AttemptRecord(
+            id=attempt_id,
+            problem_id=problem_id,
+            submitted_answer=int(submitted_answer),
+            is_correct=is_correct,
+            attempted_at=attempted_at,
+        )
+
+    def list_attempts(self, problem_id: str | None = None) -> List[AttemptRecord]:
+        query = "SELECT id, problem_id, submitted_answer, is_correct, attempted_at FROM attempts"
+        params: tuple[object, ...] = ()
+        if problem_id is not None:
+            query += " WHERE problem_id = ?"
+            params = (problem_id,)
+        query += " ORDER BY id ASC"
+
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(query, params).fetchall()
+
+        return [self._row_to_record(row) for row in rows]
+
+    def clear(self) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute("DELETE FROM attempts")
+            connection.commit()
+
+    def _row_to_record(self, row: Iterable[object]) -> AttemptRecord:
+        id_, problem_id, submitted_answer, is_correct, attempted_at = row
+        attempted_at_dt = datetime.fromisoformat(str(attempted_at))
+        if attempted_at_dt.tzinfo is None:
+            attempted_at_dt = attempted_at_dt.replace(tzinfo=timezone.utc)
+        return AttemptRecord(
+            id=int(id_),
+            problem_id=str(problem_id),
+            submitted_answer=int(submitted_answer),
+            is_correct=bool(is_correct),
+            attempted_at=attempted_at_dt,
+        )
+
+
+__all__ = ["AttemptRecord", "AttemptRepository"]
+

--- a/calculate-service/app/routers/pages.py
+++ b/calculate-service/app/routers/pages.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -39,6 +39,12 @@ def get_router(templates: Jinja2Templates) -> APIRouter:
         category: str = Query(default=None, description="문제 유형"),
     ) -> HTMLResponse:
         categories = _resolve_allowed_categories()
+        if not categories:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="등록된 문제 카테고리가 없습니다.",
+            )
+
         selected_category = category if category in categories else categories[0]
         repository = _get_repository(request)
         return templates.TemplateResponse(

--- a/calculate-service/app/routers/pages.py
+++ b/calculate-service/app/routers/pages.py
@@ -1,11 +1,16 @@
 from fastapi import APIRouter, Query, Request
-from dataclasses import asdict
-
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from ..config import get_settings
-from ..problem_bank import get_problems, list_categories
+from ..problem_bank import ProblemRepository, list_categories, refresh_cache
+
+def _get_repository(request: Request) -> ProblemRepository:
+    repository = getattr(request.app.state, "problem_repository", None)
+    if repository is None:
+        repository = refresh_cache(force=True)
+        request.app.state.problem_repository = repository
+    return repository
 
 
 def _resolve_allowed_categories() -> list[str]:
@@ -35,12 +40,21 @@ def get_router(templates: Jinja2Templates) -> APIRouter:
     ) -> HTMLResponse:
         categories = _resolve_allowed_categories()
         selected_category = category if category in categories else categories[0]
+        repository = _get_repository(request)
         return templates.TemplateResponse(
             "problems.html",
             {
                 "request": request,
                 "category": selected_category,
-                "problems": [asdict(problem) for problem in get_problems(selected_category)],
+                "problems": [
+                    {
+                        "id": problem.id,
+                        "question": problem.question,
+                        "hint": problem.hint,
+                        "category": problem.category,
+                    }
+                    for problem in repository.get_problems(selected_category)
+                ],
                 "categories": categories,
             },
         )

--- a/calculate-service/app/routers/problems.py
+++ b/calculate-service/app/routers/problems.py
@@ -1,18 +1,58 @@
-from fastapi import APIRouter, Query, status
+from datetime import datetime
 
-from dataclasses import asdict
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from pydantic import BaseModel, Field
 
 from ..config import get_settings
-from ..problem_bank import Problem, get_problems, list_categories
+from ..problem_bank import (
+    ProblemDataError,
+    ProblemRepository,
+    get_problems,
+    list_categories,
+    refresh_cache,
+)
+from ..repositories import AttemptRepository
 from fastapi.responses import JSONResponse
 
 router = APIRouter(prefix="/api", tags=["problems"])
+
+
+def _get_problem_repository(request: Request) -> ProblemRepository:
+    repository = getattr(request.app.state, "problem_repository", None)
+    if repository is None:
+        repository = refresh_cache(force=True)
+        request.app.state.problem_repository = repository
+    return repository
+
+
+def _get_attempt_repository(request: Request) -> AttemptRepository:
+    repository = getattr(request.app.state, "attempt_repository", None)
+    if repository is None:
+        settings = get_settings()
+        repository = AttemptRepository(settings.attempts_database_path)
+        request.app.state.attempt_repository = repository
+    return repository
 
 
 def _resolve_allowed_categories() -> list[str]:
     settings = get_settings()
     categories = settings.allowed_problem_categories or list_categories()
     return categories or list_categories()
+
+
+class ProblemAttemptRequest(BaseModel):
+    answer: int = Field(..., description="사용자가 제출한 답안")
+
+
+class ProblemAttemptResponse(BaseModel):
+    attempt_id: int
+    problem_id: str
+    category: str
+    is_correct: bool
+    submitted_answer: int
+    correct_answer: int
+    attempted_at: datetime
 
 
 @router.get("/categories", summary="사용 가능한 문제 카테고리 나열")
@@ -55,12 +95,55 @@ async def problems(
             },
         )
 
-    items = [asdict(problem) for problem in get_problems(selected_category)]
+    items = [problem.to_dict(include_answer=True) for problem in get_problems(selected_category)]
     return {
         "category": selected_category,
         "items": items,
         "total": len(items),
     }
+
+
+@router.post(
+    "/problems/{problem_id}/attempts",
+    status_code=status.HTTP_201_CREATED,
+    summary="문제 풀이 제출",
+    response_model=ProblemAttemptResponse,
+)
+async def submit_attempt(
+    problem_id: str,
+    payload: ProblemAttemptRequest,
+    problem_repository: ProblemRepository = Depends(_get_problem_repository),
+    attempt_repository: AttemptRepository = Depends(_get_attempt_repository),
+) -> ProblemAttemptResponse:
+    try:
+        problem = problem_repository.get_problem(problem_id)
+    except ProblemDataError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "type": "https://360me.app/problems/not-found",
+                "title": "문제를 찾을 수 없습니다",
+                "status": status.HTTP_404_NOT_FOUND,
+                "detail": f"요청한 문제 '{problem_id}'가 존재하지 않습니다.",
+            },
+        ) from None
+
+    is_correct = int(payload.answer) == problem.answer
+    record = attempt_repository.record_attempt(
+        problem_id=problem.id,
+        submitted_answer=payload.answer,
+        is_correct=is_correct,
+    )
+
+    return ProblemAttemptResponse(
+        attempt_id=record.id,
+        problem_id=record.problem_id,
+        category=problem.category,
+        is_correct=record.is_correct,
+        submitted_answer=record.submitted_answer,
+        correct_answer=problem.answer,
+        attempted_at=record.attempted_at,
+    )
 
 
 __all__ = ["router"]

--- a/calculate-service/app/templates/problems.html
+++ b/calculate-service/app/templates/problems.html
@@ -49,7 +49,7 @@
         </header>
         <div class="space-y-5" data-problem-list>
             {% for problem in problems %}
-            <article class="rounded-2xl border border-white/10 bg-slate-900/70 p-6 shadow-lg shadow-sky-900/5" data-problem-card data-problem-index="{{ loop.index0 }}">
+            <article class="rounded-2xl border border-white/10 bg-slate-900/70 p-6 shadow-lg shadow-sky-900/5" data-problem-card data-problem-index="{{ loop.index0 }}" data-problem-id="{{ problem.id }}">
                 <header class="flex flex-wrap items-center justify-between gap-3">
                     <h3 class="text-xl font-semibold text-white">
                         <span class="mr-2 inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary/20 text-base font-semibold text-primary">{{ loop.index }}</span>
@@ -119,49 +119,123 @@ function renderSummary() {
     }
 }
 
-function handleCheck(card, index, correctAnswer) {
+function setFeedback(feedbackEl, message, toneClass) {
+    if (!feedbackEl) {
+        return;
+    }
+    feedbackEl.textContent = message;
+    feedbackEl.className = `mt-3 text-sm font-semibold ${toneClass}`;
+}
+
+function extractErrorMessage(payload) {
+    if (!payload) {
+        return '답안을 채점하는 중 오류가 발생했습니다. 다시 시도해주세요.';
+    }
+    if (typeof payload.detail === 'string') {
+        return payload.detail;
+    }
+    if (Array.isArray(payload.detail) && payload.detail[0]?.msg) {
+        return payload.detail[0].msg;
+    }
+    if (payload.detail && typeof payload.detail.detail === 'string') {
+        return payload.detail.detail;
+    }
+    if (typeof payload.message === 'string') {
+        return payload.message;
+    }
+    return '답안을 채점하는 중 오류가 발생했습니다. 다시 시도해주세요.';
+}
+
+async function submitAttempt(problemId, answer) {
+    const response = await fetch(`/api/problems/${encodeURIComponent(problemId)}/attempts`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+        body: JSON.stringify({ answer }),
+    });
+
+    let payload = null;
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+        payload = await response.json();
+    }
+
+    if (!response.ok) {
+        const error = new Error(extractErrorMessage(payload));
+        error.payload = payload;
+        error.status = response.status;
+        throw error;
+    }
+
+    return payload;
+}
+
+async function handleCheck(card) {
+    const button = card.querySelector('[data-check]');
     const input = card.querySelector('[data-input]');
     const feedback = card.querySelector('[data-feedback]');
+    const problemId = card.dataset.problemId ?? '';
     const rawValue = input?.value ?? '';
-    const userAnswer = Number(rawValue);
-    if (!Number.isFinite(userAnswer) || rawValue.trim() === '') {
-        if (feedback) {
-            feedback.textContent = '답을 숫자로 입력해주세요.';
-            feedback.className = 'mt-3 text-sm font-semibold text-amber-300';
-        }
-        answered.delete(index);
+    const trimmed = rawValue.trim();
+    const userAnswer = Number(trimmed);
+
+    if (!problemId) {
+        setFeedback(feedback, '문제 정보를 찾을 수 없습니다.', 'text-amber-300');
+        return;
+    }
+
+    if (trimmed === '' || !Number.isFinite(userAnswer)) {
+        setFeedback(feedback, '답을 숫자로 입력해주세요.', 'text-amber-300');
+        answered.delete(problemId);
         renderSummary();
         return;
     }
 
-    const isCorrect = userAnswer === Number(correctAnswer);
-    if (feedback) {
-        if (isCorrect) {
-            feedback.textContent = '정답입니다! 잘했어요 🎉';
-            feedback.className = 'mt-3 text-sm font-semibold text-emerald-300';
-        } else {
-            feedback.textContent = `오답입니다. 정답은 ${correctAnswer} 입니다.`;
-            feedback.className = 'mt-3 text-sm font-semibold text-rose-300';
-        }
+    if (button) {
+        button.disabled = true;
+        button.setAttribute('aria-busy', 'true');
     }
-    answered.set(index, isCorrect);
-    renderSummary();
+
+    try {
+        const payload = await submitAttempt(problemId, userAnswer);
+        const isCorrect = Boolean(payload?.is_correct);
+        if (isCorrect) {
+            setFeedback(feedback, '정답입니다! 잘했어요 🎉', 'text-emerald-300');
+        } else {
+            const correctAnswer = payload?.correct_answer;
+            const hint = correctAnswer !== undefined ? `정답은 ${correctAnswer} 입니다.` : '다시 한번 도전해보세요!';
+            setFeedback(feedback, `오답입니다. ${hint}`, 'text-rose-300');
+        }
+        answered.set(problemId, isCorrect);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : '답안을 채점할 수 없습니다.';
+        setFeedback(feedback, message, 'text-amber-300');
+        answered.delete(problemId);
+    } finally {
+        if (button) {
+            button.disabled = false;
+            button.removeAttribute('aria-busy');
+        }
+        renderSummary();
+    }
 }
 
 function bindCard(card) {
-    const index = Number(card.dataset.problemIndex ?? '0');
     const button = card.querySelector('[data-check]');
     const input = card.querySelector('[data-input]');
-    const correctAnswer = {{ problems|tojson }}[index]?.answer;
-    if (!button || typeof correctAnswer === 'undefined') {
+    if (!button) {
         return;
     }
-    button.addEventListener('click', () => handleCheck(card, index, correctAnswer));
+    button.addEventListener('click', () => {
+        void handleCheck(card);
+    });
     if (input) {
         input.addEventListener('keypress', (event) => {
             if (event.key === 'Enter') {
                 event.preventDefault();
-                handleCheck(card, index, correctAnswer);
+                void handleCheck(card);
             }
         });
     }

--- a/calculate-service/tests/test_api.py
+++ b/calculate-service/tests/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import importlib.util
+import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -9,35 +10,72 @@ import pytest
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = SERVICE_ROOT.parent
 
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from testing_utils.sync_client import create_client  # noqa: E402
 
 
-def _load_module(module_name: str, relative_path: str):
-    module_path = SERVICE_ROOT / relative_path
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Unable to load module {module_name} from {module_path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules.setdefault(module_name, module)
-    spec.loader.exec_module(module)
-    return module
+app_module = importlib.import_module("app")
+problem_bank_module = importlib.import_module("app.problem_bank")
+config_module = importlib.import_module("app.config")
+repositories_module = importlib.import_module("app.repositories")
 
-
-calculate_service_module = _load_module(
-    "calculate_service_app", "app/__init__.py"
-)
-problem_bank_module = _load_module(
-    "calculate_service_problem_bank", "app/problem_bank.py"
-)
-create_app = calculate_service_module.create_app
+create_app = app_module.create_app
 list_categories = problem_bank_module.list_categories
+reset_problem_cache = problem_bank_module.reset_cache
+get_settings = config_module.get_settings
+AttemptRepository = repositories_module.AttemptRepository
 
 
-@pytest.fixture(scope="session")
-def app():
+@pytest.fixture
+def dataset(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    problems_path = data_dir / "problems.json"
+    attempts_path = data_dir / "attempts.db"
+    sample_problems = [
+        {
+            "id": "sample-add-1",
+            "category": "덧셈",
+            "question": "10 + 5 = ?",
+            "answer": 15,
+        },
+        {
+            "id": "sample-sub-1",
+            "category": "뺄셈",
+            "question": "10 - 3 = ?",
+            "answer": 7,
+        },
+        {
+            "id": "sample-add-2",
+            "category": "덧셈",
+            "question": "20 + 10 = ?",
+            "answer": 30,
+        },
+    ]
+    problems_path.write_text(
+        json.dumps(sample_problems, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("PROBLEM_DATA_PATH", str(problems_path))
+    monkeypatch.setenv("ATTEMPTS_DATABASE_PATH", str(attempts_path))
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    reset_problem_cache()
+
+    return {
+        "problems_path": problems_path,
+        "attempts_path": attempts_path,
+        "problems": sample_problems,
+    }
+
+
+@pytest.fixture
+def app(dataset):
     return create_app()
 
 
@@ -84,3 +122,62 @@ def test_html_routes_emit_noindex_header(client) -> None:
     response = client.get("/problems")
     assert response.status_code == 200
     assert response.headers["X-Robots-Tag"] == "noindex"
+
+
+def test_submit_correct_attempt_records_success(client, dataset) -> None:
+    target = dataset["problems"][0]
+    assert str(client._app.state.problem_repository.source_path) == str(
+        dataset["problems_path"]
+    )
+    response = client.post(
+        f"/api/problems/{target['id']}/attempts",
+        json={"answer": target["answer"]},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["is_correct"] is True
+    assert payload["correct_answer"] == target["answer"]
+    assert payload["submitted_answer"] == target["answer"]
+
+    repository = AttemptRepository(dataset["attempts_path"])
+    attempts = repository.list_attempts(target["id"])
+    assert len(attempts) == 1
+    assert attempts[0].is_correct is True
+    assert attempts[0].submitted_answer == target["answer"]
+
+
+def test_submit_incorrect_attempt_is_logged(client, dataset) -> None:
+    target = dataset["problems"][1]
+    assert str(client._app.state.problem_repository.source_path) == str(
+        dataset["problems_path"]
+    )
+    wrong_answer = target["answer"] + 5
+    response = client.post(
+        f"/api/problems/{target['id']}/attempts",
+        json={"answer": wrong_answer},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["is_correct"] is False
+    assert payload["correct_answer"] == target["answer"]
+    assert payload["submitted_answer"] == wrong_answer
+
+    repository = AttemptRepository(dataset["attempts_path"])
+    attempts = repository.list_attempts(target["id"])
+    assert len(attempts) == 1
+    assert attempts[0].is_correct is False
+    assert attempts[0].submitted_answer == wrong_answer
+
+
+def test_submit_attempt_without_answer_returns_validation_error(client, dataset) -> None:
+    target = dataset["problems"][2]
+    response = client.post(
+        f"/api/problems/{target['id']}/attempts",
+        json={},
+    )
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["detail"][0]["loc"][-1] == "answer"

--- a/calculate-service/tests/test_api.py
+++ b/calculate-service/tests/test_api.py
@@ -67,11 +67,15 @@ def dataset(tmp_path, monkeypatch):
     get_settings.cache_clear()  # type: ignore[attr-defined]
     reset_problem_cache()
 
-    return {
-        "problems_path": problems_path,
-        "attempts_path": attempts_path,
-        "problems": sample_problems,
-    }
+    try:
+        yield {
+            "problems_path": problems_path,
+            "attempts_path": attempts_path,
+            "problems": sample_problems,
+        }
+    finally:
+        reset_problem_cache()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- load problem metadata from a JSON-backed repository with startup caching and expose an attempts repository
- add POST /api/problems/{id}/attempts to validate answers, record submissions, and update the problems template to use server-side grading
- cover the new data flow with pytest fixtures exercising correct, incorrect, and invalid submissions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddece5b044832ba9ecb74daf631e8e