### PR TITLE
Fix MBTI preview chart overflow

### DIFF
--- a/mbti-arcade/app/templates/mbti/index.html
+++ b/mbti-arcade/app/templates/mbti/index.html
@@ -13,6 +13,7 @@
     .chart-card {
         position: relative;
         min-height: 18rem;
+        overflow: hidden;
     }
 
     .chart-card[aria-busy="true"]::after {
@@ -27,6 +28,16 @@
     @keyframes shimmer {
         0% { background-position: -200% 0; }
         100% { background-position: 200% 0; }
+    }
+
+    [data-preview] {
+        overflow-x: hidden;
+    }
+
+    [data-preview] canvas {
+        display: block;
+        width: 100% !important;
+        max-width: 100% !important;
     }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>


### PR DESCRIPTION
## Summary
- prevent MBTI preview chart cards from overflowing their container
- ensure preview canvases respect the layout width to remove the horizontal scrollbar

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e05d750750832b9c6b290b21f6e57e