### PR TITLE
Fix invite URL generation and host validation (TKT-001)

### DIFF
--- a/mbti-arcade/app/observability.py
+++ b/mbti-arcade/app/observability.py
@@ -77,6 +77,10 @@ def configure_observability(app: FastAPI) -> bool:
     if _INSTRUMENTED:
         return True
 
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        log.debug("Skipping OpenTelemetry instrumentation during test execution")
+        return False
+
     try:
         from opentelemetry.instrumentation.fastapi import (  # type: ignore[import]
             FastAPIInstrumentor,

--- a/mbti-arcade/app/routers/quiz.py
+++ b/mbti-arcade/app/routers/quiz.py
@@ -43,18 +43,17 @@ MBTI_QUESTIONS = [
 
 RELATIONS_ENUM = ["friend", "boyfriend", "girlfriend", "spouse", "colleague", "family"]
 
-@router.get("/{token}", response_class=HTMLResponse)
-def quiz_prefill(request: Request, token: str, session=Depends(get_session)):
+def render_invite_page(request: Request, token: str, session) -> HTMLResponse:
     try:
         pair_id, my_mbti = verify_token(token)
     except ValueError:
         raise HTTPException(status_code=403, detail="expired link")
-    
+
     svc = MBTIService(session)
     pair = svc.session.get(Pair, pair_id)
     if not pair:
         raise HTTPException(status_code=404)
-    
+
     return templates.TemplateResponse(
         "mbti/friend_test.html",
         {
@@ -67,3 +66,8 @@ def quiz_prefill(request: Request, token: str, session=Depends(get_session)):
             "relations": RELATIONS_ENUM,
         },
     )
+
+
+@router.get("/{token}", response_class=HTMLResponse, name="quiz_prefill")
+def quiz_prefill(request: Request, token: str, session=Depends(get_session)):
+    return render_invite_page(request, token, session)

--- a/mbti-arcade/app/routers/share.py
+++ b/mbti-arcade/app/routers/share.py
@@ -10,6 +10,7 @@ from slowapi.util import get_remote_address
 from app.core.db import get_session
 from app.core.services.mbti_service import MBTIService
 from app.core.token import issue_token
+from app.urling import build_invite_url
 
 limiter = Limiter(key_func=get_remote_address)
 router = APIRouter(tags=["Share"])
@@ -27,5 +28,8 @@ def make_share_link(request: Request,
     pair_id = svc.create_pair("friend", None,
                               my_name=name, my_email=email, my_mbti=my_mbti)
     token = issue_token(pair_id, my_mbti)
-    share_url = str(request.base_url.replace(path=f"/quiz/{token}"))
-    return RedirectResponse(url=f"/mbti/share_success?{urlencode({'url': share_url})}", status_code=303) 
+    share_url = build_invite_url(request, token=token)
+    return RedirectResponse(
+        url=f"/mbti/share_success?{urlencode({'url': share_url})}",
+        status_code=303,
+    )

--- a/mbti-arcade/app/urling.py
+++ b/mbti-arcade/app/urling.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from fastapi import Request
+from starlette.datastructures import URL
+
+INVITE_ROUTE_NAME = "invite_public"
+
+
+def _parse_canonical_base(raw: str | None) -> URL | None:
+    if not raw:
+        return None
+    candidate = raw.strip()
+    if not candidate:
+        return None
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    try:
+        url = URL(candidate)
+    except ValueError:
+        return None
+    if not url.scheme or not url.hostname:
+        return None
+    return url
+
+
+@lru_cache(maxsize=1)
+def _canonical_base() -> URL | None:
+    return _parse_canonical_base(os.getenv("CANONICAL_BASE_URL"))
+
+
+def build_invite_url(request: Request, token: str) -> str:
+    target_url = URL(str(request.url_for(INVITE_ROUTE_NAME, token=token)))
+    base = _canonical_base()
+    if not base:
+        return str(target_url)
+
+    base_path = base.path.rstrip("/") if base.path not in {"", "/"} else ""
+    combined_path = f"{base_path}{target_url.path}" if base_path else target_url.path
+    return str(
+        base.replace(
+            scheme=base.scheme,
+            netloc=base.netloc,
+            path=combined_path,
+            query=target_url.query,
+            fragment=target_url.fragment,
+        )
+    )

--- a/mbti-arcade/tests/integration/test_friend_route.py
+++ b/mbti-arcade/tests/integration/test_friend_route.py
@@ -1,0 +1,15 @@
+from http import HTTPStatus
+
+
+def test_friend_route_ok(client):
+    response = client.get("/mbti/friend", headers={"host": "testserver"})
+    assert response.status_code == HTTPStatus.OK
+    assert "친구 MBTI 평가" in response.text
+
+
+def test_untrusted_host_rejected(client):
+    response = client.get("http://bad.example.com/mbti/friend")
+    assert response.status_code in {HTTPStatus.BAD_REQUEST, HTTPStatus.MISDIRECTED_REQUEST}
+    body = response.json()
+    assert body["type"].startswith("https://")
+    assert body["status"] == response.status_code

--- a/mbti-arcade/tests/integration/test_share_redirect.py
+++ b/mbti-arcade/tests/integration/test_share_redirect.py
@@ -1,0 +1,26 @@
+from urllib.parse import parse_qs, urlparse
+
+
+def test_share_redirect_is_valid_url(client):
+    response = client.post(
+        "/share",
+        data={"name": "테스트", "email": "test@example.com", "my_mbti": "INTJ"},
+        follow_redirects=False,
+    )
+    assert response.status_code in {200, 302, 303}
+
+    location = response.headers.get("location", "")
+    assert location
+    assert "://" not in location or location.startswith("https://")
+
+    parsed = urlparse(location)
+    params = parse_qs(parsed.query)
+    share_url = params.get("url", [""])[0]
+    assert share_url
+    assert "/i/" in share_url
+
+    parsed_share = urlparse(share_url)
+    if parsed_share.scheme:
+        assert parsed_share.scheme in {"http", "https"}
+        assert parsed_share.netloc
+    assert parsed_share.path.startswith("/i/")

--- a/mbti-arcade/tests/test_share_flow.py
+++ b/mbti-arcade/tests/test_share_flow.py
@@ -25,10 +25,10 @@ def test_share_flow(client):
     query_params = parse_qs(parsed_url.query)
     share_url = query_params.get("url", [None])[0]
     assert share_url is not None
-    assert "/quiz/" in share_url
-    test_token = share_url.split("/quiz/")[1]
-    
-    response = client.get(f"/quiz/{test_token}")
+    assert "/i/" in share_url
+    test_token = share_url.split("/i/")[1]
+
+    response = client.get(f"/i/{test_token}")
     assert response.status_code == 200
     
     # 3. 퀴즈 제출
@@ -49,8 +49,11 @@ def test_expired_token(client):
     """만료된 토큰 테스트"""
     
     # 잘못된 토큰으로 접근
-    response = client.get("/quiz/invalid_token")
+    response = client.get("/i/invalid_token")
     assert response.status_code == 403
+    body = response.json()
+    assert body["type"].endswith("/http-403")
+    assert body["title"] == "Forbidden"
 
 def test_rate_limit_returns_problem_details(client):
     """Rate limiting 테스트"""

--- a/mbti-arcade/tests/unit/test_url_builder.py
+++ b/mbti-arcade/tests/unit/test_url_builder.py
@@ -1,0 +1,23 @@
+from starlette.requests import Request
+
+from app.urling import build_invite_url
+
+
+def test_build_invite_url_uses_url_for(app):
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+        "app": app,
+    }
+    scope["router"] = app.router
+    request = Request(scope)
+    url = build_invite_url(request, token="abc")
+    assert "/i/abc" in url


### PR DESCRIPTION
## Summary
- add a shared invite URL builder and switch share redirects plus the new /i/{token} route to use it
- introduce request host validation middleware and a Jinja escapejs filter so /mbti/friend renders reliably
- skip OpenTelemetry auto-instrumentation during pytest and add regression coverage for invite URLs and host checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e06ae549d4832b9b8990b19a2c634b