### PR TITLE
fix: ensure main service static assets are available

### DIFF
--- a/docs/main_service_static_issue.md
+++ b/docs/main_service_static_issue.md
@@ -1,0 +1,33 @@
+# Main Service Startup Failure Report
+
+## Summary
+- **Affected service:** `main-service`
+- **Detected issue:** Application failed to start because the static assets directory referenced during startup was missing.
+- **Resolution:** Create and track the missing `app/static` directory, provide a baseline stylesheet, and update the FastAPI application to resolve paths relative to the module so startup no longer depends on the working directory.
+
+## Observed Symptoms
+- Running `uvicorn app.main:app --reload --port 8000` exited immediately.
+- The reloader traceback ended with:
+  ```text
+  RuntimeError: Directory 'app/static' does not exist
+  ```
+- Because the exception occurs during application import, the service never binds to the configured port, making health checks and the homepage unavailable.
+
+## Root Cause Analysis
+- `main-service/app/main.py` mounted a static directory using `StaticFiles(directory="app/static")`.
+- The repository did not include an `app/static/` directory, so Starlette raised a runtime error while mounting static files during application startup.
+- The relative path also relied on the process working directory. Launching the service from a different directory (e.g., repository root) would continue to fail even if the folder were later added.
+
+## Resolution Steps
+1. Added pathlib-based path resolution in `main.py` to compute the static and template directories relative to the module file.
+2. Ensured the static directory exists at runtime with `mkdir(parents=True, exist_ok=True)` so the service can start even before assets are added.
+3. Created `app/static/styles.css` as a starter stylesheet and linked it from the base template so static files are served successfully.
+
+## Verification
+- After applying the changes, starting the service with `uvicorn app.main:app --reload --port 8000` no longer raises the missing directory error.
+- The homepage now loads successfully and serves the linked `/static/styles.css` asset.
+
+## Recommendations
+- Keep static assets under version control to avoid regressions.
+- Consider adding an automated startup check (e.g., unit test) that imports the FastAPI application to catch missing directories during CI.
+- Document the expected project layout in developer onboarding guides so future contributors create required folders alongside template changes.

--- a/main-service/app/main.py
+++ b/main-service/app/main.py
@@ -1,32 +1,44 @@
+from pathlib import Path
 from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi.responses import HTMLResponse
 import os
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+# Ensure the static directory exists so the app can start even without assets yet.
+STATIC_DIR.mkdir(parents=True, exist_ok=True)
 
 app = FastAPI(
     title="Web Service Hub",
     description="다양한 웹 서비스를 관리하는 중앙 허브",
-    version="1.0.0"
+    version="1.0.0",
 )
 
-# 정적 파일 마운트
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
+# Mount static files relative to this module for predictable paths.
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-# 템플릿 설정
-templates = Jinja2Templates(directory="app/templates")
+# Configure Jinja templates directory.
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
     """메인 홈페이지"""
     return templates.TemplateResponse("index.html", {"request": request})
 
+
 @app.get("/health")
 async def health_check():
     """헬스 체크 엔드포인트"""
     return {"status": "healthy", "message": "Web Service Hub is running!"}
 
+
 if __name__ == "__main__":
     import uvicorn
+
     port = int(os.environ.get("PORT", 8080))
-    uvicorn.run(app, host="0.0.0.0", port=port) 
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/main-service/app/static/styles.css
+++ b/main-service/app/static/styles.css
@@ -1,0 +1,9 @@
+/* Basic layout enhancements for the Web Service Hub */
+body {
+    background-color: #020617;
+    color: #e2e8f0;
+}
+
+a {
+    color: inherit;
+}

--- a/main-service/app/templates/base.html
+++ b/main-service/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="360Me 서비스들을 한 눈에 정리한 웹 허브">
     <title>{% block title %}360Me Web Service Hub{% endblock %}</title>
+    <link rel="stylesheet" href="/static/styles.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {


### PR DESCRIPTION
## Summary
- resolve the main service's static and template paths relative to the module and ensure the static directory exists at startup
- add a baseline stylesheet and reference it from the shared base template so `/static` is served successfully
- document the outage analysis and remediation steps in `docs/main_service_static_issue.md`

## Testing
- uvicorn app.main:app --reload --port 8000


------
https://chatgpt.com/codex/tasks/task_e_68e0711958d4832bb82fd8683e67c344