### PR TITLE
Restore calculate proxy and CTA

### DIFF
--- a/mbti-arcade/app/templates/base.html
+++ b/mbti-arcade/app/templates/base.html
@@ -59,6 +59,9 @@
                             <a href="/mbti/friend" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                 👥 친구 MBTI 평가
                             </a>
+                            <a href="/calculate" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                ➗ 수학 연산 연습
+                            </a>
                             <div class="border-t border-gray-100 my-1"></div>
                             <div class="px-4 py-2 text-xs text-gray-500">
                                 곧 추가될 예정:
@@ -137,6 +140,9 @@
                             <a href="/mbti/friend" class="block py-1 text-sm text-gray-600 hover:text-blue-600 transition-colors">
                                 👥 친구 MBTI 평가
                             </a>
+                            <a href="/calculate" class="block py-1 text-sm text-gray-600 hover:text-blue-600 transition-colors">
+                                ➗ 수학 연산 연습
+                            </a>
                         </div>
                     </div>
                     
@@ -173,15 +179,17 @@
                     <div class="flex space-x-4">
                         <a href="/" class="text-gray-400 hover:text-white transition-colors">홈</a>
                         <a href="/mbti" class="text-gray-400 hover:text-white transition-colors">MBTI</a>
+                        <a href="/calculate" class="text-gray-400 hover:text-white transition-colors">수학 연산</a>
                         <a href="/arcade" class="text-gray-400 hover:text-white transition-colors">게임</a>
                     </div>
                 </div>
-                
+
                 <div>
                     <h4 class="text-md font-semibold mb-3">🔍 검사 서비스</h4>
                     <ul class="space-y-2 text-sm text-gray-400">
                         <li><a href="/mbti" class="hover:text-white transition-colors">MBTI 성격 유형</a></li>
                         <li><a href="/mbti/friend" class="hover:text-white transition-colors">친구 MBTI 평가</a></li>
+                        <li><a href="/calculate" class="hover:text-white transition-colors">수학 연산 연습</a></li>
                         <li class="text-gray-500">에니어그램 (준비 중)</li>
                         <li class="text-gray-500">사랑의 언어 (준비 중)</li>
                     </ul>

--- a/mbti-arcade/app/templates/index.html
+++ b/mbti-arcade/app/templates/index.html
@@ -20,19 +20,42 @@
                 <div class="text-5xl mb-4">🧠</div>
                 <h3 class="text-xl font-bold text-gray-800 mb-3">MBTI 성격 유형</h3>
                 <p class="text-gray-600 mb-4 text-sm">
-                    당신의 성격 유형을 알아보세요! 
+                    당신의 성격 유형을 알아보세요!
                     개인 테스트와 친구 평가 모드를 제공합니다.
                 </p>
                 <div class="space-y-2">
-                    <a href="/mbti" 
+                    <a href="/mbti"
                        class="block w-full bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm">
                         개인 테스트
                     </a>
-                    <a href="/mbti/friend" 
+                    <a href="/mbti/friend"
                        class="block w-full bg-purple-600 text-white px-4 py-2 rounded-lg hover:bg-purple-700 transition-colors text-sm">
                         친구 평가
                     </a>
                 </div>
+            </div>
+
+            <!-- Calculate Service CTA -->
+            <div class="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+                <div class="text-5xl mb-4">➗</div>
+                <h3 class="text-xl font-bold text-gray-800 mb-3">수학 연산 연습</h3>
+                <p class="text-gray-600 mb-4 text-sm">
+                    초등 연산 문제로 실력을 다져보세요.
+                    덧셈, 뺄셈, 곱셈, 나눗셈을 난이도별로 제공합니다.
+                </p>
+                <div class="space-y-2">
+                    <a href="/calculate"
+                       class="block w-full bg-teal-600 text-white px-4 py-2 rounded-lg hover:bg-teal-700 transition-colors text-sm">
+                        서비스 소개
+                    </a>
+                    <a href="/calculate/problems"
+                       class="block w-full bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm">
+                        문제 바로 풀기
+                    </a>
+                </div>
+                <p class="mt-4 text-xs text-gray-500">
+                    모든 페이지는 noindex 처리되어 안전한 학습 공간을 제공합니다.
+                </p>
             </div>
 
             <!-- 향후 추가될 검사들 -->

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -71,6 +71,24 @@ server {
         proxy_set_header CF-Visitor $http_cf_visitor;
     }
 
+    # Calculate Service - /calculate path
+    location = /calculate {
+        return 301 /calculate/;
+    }
+
+    location /calculate/ {
+        rewrite ^/calculate/(.*)$ /$1 break;
+        proxy_pass http://calculate-service:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /calculate;
+        proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+        proxy_set_header CF-RAY $http_cf_ray;
+        proxy_set_header CF-Visitor $http_cf_visitor;
+    }
+
     # MBTI Service - /mbti path
     location /mbti {
         rewrite ^/mbti/(.*) /mbti/$1 break;


### PR DESCRIPTION
## Summary
- restore the `/calculate` reverse proxy in `nginx/conf.d/default.conf` so requests are forwarded to the calculate-service container with the expected headers
- surface the calculate practice experience throughout the MBTI landing templates with navigation links, footer links, and a dedicated CTA card

## Testing
- pytest mbti-arcade/tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a21337cc832ba72191158c64ede2