### PR TITLE
fix: accept 360me domains as allowed hosts

### DIFF
--- a/mbti-arcade/app/main.py
+++ b/mbti-arcade/app/main.py
@@ -94,6 +94,10 @@ _DEFAULT_ALLOWED_HOSTS = {
     "127.0.0.1",
     "127.0.0.1:8000",
     "testserver",
+    "360me.app",
+    "www.360me.app",
+    "api.360me.app",
+    "*.360me.app",
 }
 
 

--- a/mbti-arcade/tests/test_host_validation.py
+++ b/mbti-arcade/tests/test_host_validation.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from fastapi import FastAPI
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+from app.main import HostValidationMiddleware, _load_allowed_hosts
+
+
+def test_default_allowed_hosts_include_public_domains(monkeypatch):
+    monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
+    allowed_hosts = _load_allowed_hosts()
+
+    assert "360me.app" in allowed_hosts
+    assert "*.360me.app" in allowed_hosts
+    assert "api.360me.app" in allowed_hosts
+
+
+def test_host_validation_allows_primary_domain():
+    app = FastAPI()
+    middleware = HostValidationMiddleware(app, allowed_hosts=["*.360me.app", "360me.app"])
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"host", b"api.360me.app")],
+        "query_string": b"",
+        "server": ("api.360me.app", 443),
+        "scheme": "https",
+    }
+    request = Request(scope)
+
+    async def call_next(req: Request):
+        return PlainTextResponse("ok")
+
+    async def run() -> None:
+        response = await middleware.dispatch(request, call_next)
+        assert response.status_code == 200
+        assert response.body == b"ok"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add 360me production domains to the default allowed host list so external traffic is accepted
- cover the new defaults and middleware behavior with focused regression tests

## Testing
- pytest tests/test_host_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68e0bf7b3218832b958ce7cb334a4bc1