### PR TITLE
Allow container host defaults for MBTI service

### DIFF
--- a/mbti-arcade/app/settings.py
+++ b/mbti-arcade/app/settings.py
@@ -9,6 +9,8 @@ _DEFAULT_ALLOWED_HOSTS = (
     "127.0.0.1",
     "localhost:8000",
     "127.0.0.1:8000",
+    "0.0.0.0",
+    "0.0.0.0:8000",
     "testserver",
 )
 


### PR DESCRIPTION
## Summary
- add 0.0.0.0 host variants to the default ALLOWED_HOSTS list so container-bound requests are accepted by TrustedHostMiddleware

## Testing
- pytest tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68e1aa4eb168832b8c29b8afbfdace4e