### PR TITLE
fix: update calculate service links

### DIFF
--- a/mbti-arcade/app/main.py
+++ b/mbti-arcade/app/main.py
@@ -92,6 +92,14 @@ app = FastAPI(
 
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+_calculate_base_url = settings.CALCULATE_SERVICE_BASE_URL or "/"
+if _calculate_base_url != "/":
+    _calculate_base_url = _calculate_base_url.rstrip("/")
+templates.env.globals.setdefault("calculate_service_url", _calculate_base_url)
+templates.env.globals.setdefault(
+    "calculate_service_problems_url",
+    f"{_calculate_base_url}/problems" if _calculate_base_url != "/" else "/problems",
+)
 
 
 def _escape_js(value: object) -> str:

--- a/mbti-arcade/app/settings.py
+++ b/mbti-arcade/app/settings.py
@@ -31,6 +31,22 @@ def _clean_hosts(raw_hosts: str) -> list[str]:
 CANONICAL_BASE_URL = os.getenv("CANONICAL_BASE_URL", "").strip()
 
 
+def _resolve_calculate_service_base_url() -> str:
+    """Return the public base URL for the standalone calculate service."""
+
+    declared_urls = (
+        os.getenv("CALCULATE_SERVICE_URL", "").strip(),
+        os.getenv("CALCULATE_SERVICE_BASE_URL", "").strip(),
+    )
+
+    for candidate in declared_urls:
+        if candidate:
+            normalized = candidate.rstrip("/")
+            return normalized or "/"
+
+    return "https://calc.360me.app"
+
+
 def _load_allowed_hosts() -> list[str]:
     declared = _clean_hosts(os.getenv("ALLOWED_HOSTS", ""))
 
@@ -51,4 +67,7 @@ def _load_allowed_hosts() -> list[str]:
 
 
 ALLOWED_HOSTS = _load_allowed_hosts()
+
+
+CALCULATE_SERVICE_BASE_URL = _resolve_calculate_service_base_url()
 

--- a/mbti-arcade/app/templates/base.html
+++ b/mbti-arcade/app/templates/base.html
@@ -59,7 +59,7 @@
                             <a href="/mbti/friend" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                 👥 친구 MBTI 평가
                             </a>
-                            <a href="/calculate" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                            <a href="{{ calculate_service_url }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                 ➗ 수학 연산 연습
                             </a>
                             <div class="border-t border-gray-100 my-1"></div>
@@ -140,7 +140,7 @@
                             <a href="/mbti/friend" class="block py-1 text-sm text-gray-600 hover:text-blue-600 transition-colors">
                                 👥 친구 MBTI 평가
                             </a>
-                            <a href="/calculate" class="block py-1 text-sm text-gray-600 hover:text-blue-600 transition-colors">
+                            <a href="{{ calculate_service_url }}" class="block py-1 text-sm text-gray-600 hover:text-blue-600 transition-colors">
                                 ➗ 수학 연산 연습
                             </a>
                         </div>
@@ -179,7 +179,7 @@
                     <div class="flex space-x-4">
                         <a href="/" class="text-gray-400 hover:text-white transition-colors">홈</a>
                         <a href="/mbti" class="text-gray-400 hover:text-white transition-colors">MBTI</a>
-                        <a href="/calculate" class="text-gray-400 hover:text-white transition-colors">수학 연산</a>
+                        <a href="{{ calculate_service_url }}" class="text-gray-400 hover:text-white transition-colors">수학 연산</a>
                         <a href="/arcade" class="text-gray-400 hover:text-white transition-colors">게임</a>
                     </div>
                 </div>
@@ -189,7 +189,7 @@
                     <ul class="space-y-2 text-sm text-gray-400">
                         <li><a href="/mbti" class="hover:text-white transition-colors">MBTI 성격 유형</a></li>
                         <li><a href="/mbti/friend" class="hover:text-white transition-colors">친구 MBTI 평가</a></li>
-                        <li><a href="/calculate" class="hover:text-white transition-colors">수학 연산 연습</a></li>
+                        <li><a href="{{ calculate_service_url }}" class="hover:text-white transition-colors">수학 연산 연습</a></li>
                         <li class="text-gray-500">에니어그램 (준비 중)</li>
                         <li class="text-gray-500">사랑의 언어 (준비 중)</li>
                     </ul>

--- a/mbti-arcade/app/templates/index.html
+++ b/mbti-arcade/app/templates/index.html
@@ -44,11 +44,11 @@
                     덧셈, 뺄셈, 곱셈, 나눗셈을 난이도별로 제공합니다.
                 </p>
                 <div class="space-y-2">
-                    <a href="/calculate"
+                    <a href="{{ calculate_service_url }}"
                        class="block w-full bg-teal-600 text-white px-4 py-2 rounded-lg hover:bg-teal-700 transition-colors text-sm">
                         서비스 소개
                     </a>
-                    <a href="/calculate/problems"
+                    <a href="{{ calculate_service_problems_url }}"
                        class="block w-full bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm">
                         문제 바로 풀기
                     </a>


### PR DESCRIPTION
## Summary
- add a configurable calculate service base URL so templates can point to the standalone math app
- update shared navigation and landing CTA links to use the configured calculate service endpoints

## Testing
- pytest tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c271fd7c832bb7e22cee132aeb38