### PR TITLE
fix: ensure preview result includes unlocked flag

### DIFF
--- a/mbti-arcade/app/routers/results.py
+++ b/mbti-arcade/app/routers/results.py
@@ -29,6 +29,7 @@ PREVIEW_RESULT = ResultDetail(
     gap_score=PREVIEW_GAP_SCORE,
     radar_self=norm_to_radar(PREVIEW_SELF_NORM),
     radar_other=norm_to_radar(PREVIEW_OTHER_NORM),
+    unlocked=True,
 )
 
 


### PR DESCRIPTION
## Summary
- set the preview result payload to mark the demo session as unlocked so it satisfies the ResultDetail schema

## Testing
- pytest *(fails: existing invite/report/share flows and questionnaire count assertions in the baseline suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e227d48c832ba711e5c507dd8c6c