### PR TITLE
Use canonical invite URL in friend results view

### DIFF
--- a/mbti-arcade/app/main.py
+++ b/mbti-arcade/app/main.py
@@ -134,6 +134,7 @@ from app.routers import sessions as sessions_router
 from app.routers import share as share_router
 from app.routers import invites as invites_router
 from app.observability import bind_request_id, configure_observability, reset_request_id
+from app.urling import build_invite_url
 from app.utils.problem_details import (
     ProblemDetailsException,
     from_exception,
@@ -709,6 +710,8 @@ async def mbti_friend_result(request: Request, token: str):
         }
     }
 
+    invite_url = build_invite_url(request, token)
+
     response = templates.TemplateResponse(
         "mbti/friend_results.html",
         {
@@ -716,10 +719,10 @@ async def mbti_friend_result(request: Request, token: str):
             "mbti_type": mbti_type,
             "scores": scores,
             "result": result,
-            "pair_token": token,
             "my_mbti": my_mbti,
             "friend_info": friend_info,
             "statistics": statistics,
+            "invite_url": invite_url,
             "robots_meta": NOINDEX_VALUE,
         },
     )

--- a/mbti-arcade/app/templates/mbti/friend_results.html
+++ b/mbti-arcade/app/templates/mbti/friend_results.html
@@ -13,11 +13,7 @@
 {% set owner_name = friend_info.display_name or friend_info.name or '친구' %}
 {% set perceived_mbti = mbti_type %}
 {% set owner_mbti = friend_info.mbti %}
-{% if pair_token %}
-    {% set invite_url = request.url_for('invite_public', token=pair_token) %}
-{% else %}
-    {% set invite_url = '' %}
-{% endif %}
+{% set invite_url = invite_url | default('') %}
 <div class="mx-auto max-w-4xl space-y-10 py-10">
     <section class="rounded-3xl bg-gradient-to-br from-indigo-600 via-sky-500 to-emerald-500 px-6 py-10 text-white shadow-xl">
         <div class="flex flex-col items-center gap-6 text-center md:flex-row md:text-left">

--- a/mbti-arcade/tests/test_share_flow.py
+++ b/mbti-arcade/tests/test_share_flow.py
@@ -1,14 +1,15 @@
 from urllib.parse import parse_qs, urlparse
 
+from app import settings
+
 
 def test_share_flow(client):
     """공유 링크 생성 → 퀴즈 → 결과 플로우 테스트"""
     
     # 1. 공유 링크 생성
     share_data = {
-        "name": "테스트 사용자",
-        "email": "test@example.com",
-        "my_mbti": "INTJ"
+        "display_name": "테스트 사용자",
+        "mbti_value": "INTJ",
     }
     
     response = client.post("/share", data=share_data, follow_redirects=False)
@@ -45,6 +46,11 @@ def test_share_flow(client):
     response = client.post(f"/mbti/result/{test_token}", data=quiz_data)
     assert response.status_code == 200
 
+    html = response.text
+    expected_prefix = f"{settings.CANONICAL_BASE_URL}/i/"
+    assert expected_prefix in html
+    assert "testserver" not in html
+
 def test_expired_token(client):
     """만료된 토큰 테스트"""
     
@@ -59,9 +65,8 @@ def test_rate_limit_returns_problem_details(client):
     """Rate limiting 테스트"""
 
     share_data = {
-        "name": "테스트 사용자",
-        "email": "test@example.com",
-        "my_mbti": "INTJ",
+        "display_name": "테스트 사용자",
+        "mbti_value": "INTJ",
     }
 
     first = client.post("/share", data=share_data, follow_redirects=False)


### PR DESCRIPTION
## Summary
- compute the invite link for friend results with `build_invite_url` so it is always canonical
- update the friend results template to rely on the provided invite URL instead of building it from `request`
- refresh the share flow tests to use the current form fields and assert the canonical host appears in the rendered link

## Testing
- DATABASE_URL=sqlite:///./perception_gap_test.db pytest tests/test_share_flow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e593bb4ab8832b90a51f8219bfbcf3