### PR TITLE
Expose canonical invite URL in invite responses

### DIFF
--- a/mbti-arcade/app/main.py
+++ b/mbti-arcade/app/main.py
@@ -799,7 +799,10 @@ def invite_public(
 
     if session_record is not None:
         now = datetime.now(timezone.utc)
-        if session_record.expires_at <= now:
+        expires_at = session_record.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at <= now:
             owner_name = session_record.snapshot_owner_name or "초대한 분"
             return problem_response(
                 request,

--- a/mbti-arcade/app/routers/invites.py
+++ b/mbti-arcade/app/routers/invites.py
@@ -9,6 +9,7 @@ from app.core.config import compute_expiry, generate_invite_token, generate_sess
 from app.database import get_db
 from app.models import OwnerProfile, Session as SessionModel
 from app.schemas import InviteCreateRequest, InviteCreateResponse
+from app.urling import build_invite_url
 from app.utils.auth import extract_owner_key
 from app.utils.problem_details import ProblemDetailsException
 
@@ -60,9 +61,12 @@ def create_invite(
     db.add(session)
     db.commit()
 
+    invite_url = build_invite_url(request, token=session.invite_token)
+
     return InviteCreateResponse(
         session_id=session.id,
         invite_token=session.invite_token,
+        invite_url=invite_url,
         expires_at=session.expires_at,
         max_raters=session.max_raters,
         show_public=profile.show_public,

--- a/mbti-arcade/app/schemas.py
+++ b/mbti-arcade/app/schemas.py
@@ -287,6 +287,7 @@ class InviteCreateRequest(BaseModel):
 class InviteCreateResponse(BaseModel):
     session_id: str
     invite_token: str
+    invite_url: str
     expires_at: datetime
     max_raters: int
     show_public: bool

--- a/mbti-arcade/docs/product/Tickets.md
+++ b/mbti-arcade/docs/product/Tickets.md
@@ -119,7 +119,7 @@ TKT‑003 초대 링크 발급(/i/{token}) + 만료/정원 + 서버 헤더 렌�
 
 수락 기준
 
-POST /v1/invites → 201 {token, expires_at, max_raters}
+POST /v1/invites → 201 {token, invite_url, expires_at, max_raters}
 
 GET /i/{token} → 200, HTML에 표시명/아바타 보임
 

--- a/mbti-arcade/tests/integration/test_invites_api.py
+++ b/mbti-arcade/tests/integration/test_invites_api.py
@@ -34,6 +34,9 @@ def test_invite_issue_and_render(client, auth_headers):
 
     body = response.json()
     token = body["invite_token"]
+    assert body["invite_url"] == (
+        f"https://webservice-production-c039.up.railway.app/i/{token}"
+    )
     assert body["owner_display_name"] == PROFILE_PAYLOAD["display_name"]
     assert body["owner_avatar_url"] == PROFILE_PAYLOAD["avatar_url"]
 
@@ -53,6 +56,9 @@ def test_invite_expired_returns_problem_detail(client, auth_headers):
     data = response.json()
     token = data["invite_token"]
     session_id = data["session_id"]
+    assert data["invite_url"] == (
+        f"https://webservice-production-c039.up.railway.app/i/{token}"
+    )
 
     with session_scope() as db:
         session = db.get(SessionModel, session_id)
@@ -74,6 +80,9 @@ def test_invite_capacity_returns_problem_detail(client, auth_headers):
     data = response.json()
     token = data["invite_token"]
     session_id = data["session_id"]
+    assert data["invite_url"] == (
+        f"https://webservice-production-c039.up.railway.app/i/{token}"
+    )
 
     with session_scope() as db:
         participant = Participant(


### PR DESCRIPTION
## Summary
- add the invite_url field to InviteCreateResponse and build the canonical URL in the invites router
- extend integration coverage and docs to assert the canonical invite URL that clients should use
- harden invite expiry checks against naive datetimes when rendering the invite page

## Testing
- pytest tests/integration/test_invites_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e593bda95c832b83e511a5be334679